### PR TITLE
LLDB fails to build

### DIFF
--- a/scripts/Python/python-swigsafecast.swig
+++ b/scripts/Python/python-swigsafecast.swig
@@ -30,7 +30,11 @@ PyObject*
 SBTypeToSWIGWrapper (const char* c_str)
 {
     if (c_str)
-        return PyString_FromString(c_str);
+        #if PY_MAJOR_VERSION > 2
+            return PyUnicode_FromString(c_str);
+        #else
+            return PyString_FromString(c_str);
+        #endif
     return NULL;
 }
 


### PR DESCRIPTION
In Linux environment where Python 3 exists (even if it's not set as default) script uses Python 3 instead of Python 2. In Python 3 PyString_FromString() doesn't exist anymore.

Tested in Gentoo Linux